### PR TITLE
Upgrade gulp-autoprefixer and sync options with angular-material

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task('less', function () {
 	gulp.src(paths.src.less)
 		.pipe(less({strictMath: true}))
 		.pipe(concat(moduleName + '.css'))
-		.pipe(autoprefix({browsers: ['> 1%'], cascade: true}))
+		.pipe(autoprefix({browsers: ['last 2 versions', 'last 4 Android versions']}))
 		.pipe(gulp.dest(paths.dist))
 		.pipe(rename({extname: '.min.css'}))
 		.pipe(minifyCss())

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "del": "^2.0.1",
     "gulp": "^3.9.0",
     "gulp-angular-templatecache": "^1.7.0",
-    "gulp-autoprefixer": "^2.3.1",
+    "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.6.0",
     "gulp-debug": "^2.1.0",
     "gulp-inject-reload": "0.0.2",


### PR DESCRIPTION
This PR upgrades [gulp-autoprefixer](https://github.com/sindresorhus/gulp-autoprefixer) and syncs its options with [angular-material](https://github.com/angular/material/blob/17f4bf49b268b473619b2253b009e721b13cd797/gulp/util.js#L73-L75). Since this module is tightly coupled to angular-material it would benefit from using the same CSS prefixing rules.

The `cascade` option is removed since that it had the default value ([docs](https://github.com/postcss/autoprefixer/blob/d7ac944748579dc960d91b93ba12462a4089954f/README.md)).

I did not include the dist CSS files in this commit since I think it can be easier pulled on top of #32 this way. Is that correct?
