### PR TITLE
Prevent IE 11 and bellow from showing a clear button

### DIFF
--- a/src/less/mdColorPicker.less
+++ b/src/less/mdColorPicker.less
@@ -18,8 +18,9 @@ md-color-picker .md-color-picker-input-container,
 	&.md-input-focused label:not(.md-no-float), &.md-input-has-value label:not(.md-no-float) {
 		//padding-left: 2px;
 	}
-	input {
-	//	margin-left: 30px;
+	//remove clear X button from IE input fields
+	input::-ms-clear {
+	    display: none;
 	}
 	.md-color-picker-preview {
 	//	position: absolute;

--- a/src/less/mdColorPicker.less
+++ b/src/less/mdColorPicker.less
@@ -19,7 +19,7 @@ md-color-picker .md-color-picker-input-container,
 		//padding-left: 2px;
 	}
 	//remove clear X button from IE input fields
-	input::-ms-clear {
+	.md-color-picker-input::-ms-clear {
 	    display: none;
 	}
 	.md-color-picker-preview {


### PR DESCRIPTION
When the input is focused in IE, the browsers native clear button appears overall ping with the color pickers clear button.

Replacing PR #63 
